### PR TITLE
Support for LFS 0.6T (InSim version 8)

### DIFF
--- a/InSimDotNet/InSim.cs
+++ b/InSimDotNet/InSim.cs
@@ -14,7 +14,7 @@ namespace InSimDotNet {
         /// <summary>
         /// Gets the current InSim version.
         /// </summary>
-        public const int InSimVersion = 7;
+        public const int InSimVersion = 8;
         private const string RelayHost = "isrelay.lfs.net";
         private const int RelayPort = 47474;
 

--- a/InSimDotNet/InSimDotNet.csproj
+++ b/InSimDotNet/InSimDotNet.csproj
@@ -94,10 +94,12 @@
     <Compile Include="Packets\ContactFlags.cs" />
     <Compile Include="Packets\CSCAction.cs" />
     <Compile Include="Packets\FlagType.cs" />
+    <Compile Include="Packets\GarageSubMode.cs" />
     <Compile Include="Packets\HlvcFlags.cs" />
     <Compile Include="Packets\HostType.cs" />
     <Compile Include="Packets\IS_ACR.cs" />
     <Compile Include="Packets\IS_AXM.cs" />
+    <Compile Include="Packets\IS_CIM.cs" />
     <Compile Include="Packets\IS_CON.cs" />
     <Compile Include="Packets\IS_CSC.cs" />
     <Compile Include="Packets\IS_HCP.cs" />
@@ -113,6 +115,8 @@
     <Compile Include="Packets\JrrAction.cs" />
     <Compile Include="Packets\LfsLanguage.cs" />
     <Compile Include="Packets\LocalCarSwitches.cs" />
+    <Compile Include="Packets\MarshallObjectType.cs" />
+    <Compile Include="Packets\ModeIdentifier.cs" />
     <Compile Include="Packets\ObjectFlags.cs" />
     <Compile Include="Packets\ObjectInfo.cs" />
     <Compile Include="Packets\OCOAction.cs" />
@@ -120,6 +124,8 @@
     <Compile Include="Packets\PlayerTypes.cs" />
     <Compile Include="Packets\PMOFlags.cs" />
     <Compile Include="Packets\ReplayMode.cs" />
+    <Compile Include="Packets\NormalSubMode.cs" />
+    <Compile Include="Packets\ShiftUSubMode.cs" />
     <Compile Include="Packets\TtcType.cs" />
     <Compile Include="Packets\Tyres.cs" />
     <Compile Include="Packets\UCOAction.cs" />

--- a/InSimDotNet/PacketFactory.cs
+++ b/InSimDotNet/PacketFactory.cs
@@ -131,6 +131,8 @@ namespace InSimDotNet {
                     return new IS_SLC(buffer);
                 case PacketType.ISP_CSC:
                     return new IS_CSC(buffer);
+                case PacketType.ISP_CIM:
+                    return new IS_CIM(buffer);
                 case PacketType.IRP_ARP:
                     return new IR_ARP(buffer);
                 case PacketType.IRP_HOS:
@@ -286,6 +288,8 @@ namespace InSimDotNet {
                 return PacketType.ISP_SLC;
             if (type == typeof(IS_CSC))
                 return PacketType.ISP_CSC;
+            if (type == typeof(IS_CIM))
+                return PacketType.ISP_CIM;
             if (type == typeof(IR_ARP))
                 return PacketType.IRP_ARP;
             if (type == typeof(IR_ARQ))

--- a/InSimDotNet/Packets/ActionFlags.cs
+++ b/InSimDotNet/Packets/ActionFlags.cs
@@ -37,5 +37,15 @@
         /// Set the current editor selection.
         /// </summary>
         PMO_SELECTION,
+
+        /// <summary>
+        /// User pressed O without anything selected
+        /// </summary>
+        PMO_POSITION,
+
+        /// <summary>
+        /// Request Z values / reply with Z values
+        /// </summary>
+        PMO_GET_Z
     }
 }

--- a/InSimDotNet/Packets/GarageSubMode.cs
+++ b/InSimDotNet/Packets/GarageSubMode.cs
@@ -1,0 +1,52 @@
+﻿namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Submode identifiers to represent the IS_CIM SubMode attribute when Mode
+    /// is set to CIM_GARAGE.
+    /// </summary>
+    public enum GarageSubMode {
+        /// <summary>
+        /// General information pane.
+        /// </summary>
+        GRG_INFO,
+
+        /// <summary>
+        /// Colours adjustment pane.
+        /// </summary>
+        GRG_COLOURS,
+
+        /// <summary>
+        /// Braking and traction control pane.
+        /// </summary>
+        GRG_BRAKE_TC,
+
+        /// <summary>
+        /// Suspension adjustment pane.
+        /// </summary>
+        GRG_SUSP,
+
+        /// <summary>
+        /// Steering adjustment pane.
+        /// </summary>
+        GRG_STEER,
+
+        /// <summary>
+        /// Drivetrain configuration pane (e.g. transmission, differentials).
+        /// </summary>
+        GRG_DRIVE,
+
+        /// <summary>
+        /// Tyres selection pane.
+        /// </summary>
+        GRG_TYRES,
+
+        /// <summary>
+        /// Aero dynamism of the car (if available).
+        /// </summary>
+        GRG_AERO,
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        GRG_PASS
+    }
+}

--- a/InSimDotNet/Packets/IS_CIM.cs
+++ b/InSimDotNet/Packets/IS_CIM.cs
@@ -1,0 +1,73 @@
+﻿using System;
+
+namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Connection interface mode packet.
+    /// </summary>
+    /// <remarks>
+    /// Reports a connection's interface mode.
+    /// </remarks>
+    public class IS_CIM : IPacket {
+        /// <summary>
+        /// Gets the size of the packet.
+        /// </summary>
+        public byte Size { get; private set; }
+
+        /// <summary>
+        /// Gets the type of the packet.
+        /// </summary>
+        public PacketType Type { get; private set; }
+
+        /// <summary>
+        /// Gets the packet request ID, as received in the <see cref="IS_BTN"/> packet.
+        /// </summary>
+        public byte ReqI { get; private set; }
+
+        /// <summary>
+        /// Gets the unique ID of the connection that used the button (zero if local).
+        /// </summary>
+        public byte UCID { get; private set; }
+
+        /// <summary>
+        /// Gets which mode the connection is currently in.
+        /// </summary>
+        public ModeIdentifier Mode { get; private set; }
+
+        /// <summary>
+        /// Gets the submode identifiers. Its value depends of the connection mode.
+        /// Corresponding enums for each supported mode are available.
+        /// </summary>
+        public byte SubMode { get; private set; }
+
+        /// <summary>
+        /// Gets the selected object type (or zero if unselected).
+        /// It may be an AXO_x as in ObjectInfo or one of the marshall enum values.
+        /// </summary>
+        public byte SelType { get; private set; }
+
+        /// <summary>
+        /// Creates a new connection interface mode packet.
+        /// </summary>
+        public IS_CIM() {
+            Size = 8;
+            Type = PacketType.ISP_CIM;
+        }
+
+        /// <summary>
+        /// Creates a new connection interface mode packet.
+        /// </summary>
+        /// <param name="buffer">A buffer contaning the packet data.</param>
+        public IS_CIM(byte[] buffer)
+            : this() {
+            var reader = new PacketReader(buffer);
+            Size = reader.ReadByte();
+            Type = (PacketType)reader.ReadByte();
+            ReqI = reader.ReadByte();
+            UCID = reader.ReadByte();
+            Mode = (ModeIdentifier)reader.ReadByte();
+            SubMode = reader.ReadByte();
+            SelType = reader.ReadByte();
+            reader.Skip(1);
+        }
+    }
+}

--- a/InSimDotNet/Packets/MarshallObjectType.cs
+++ b/InSimDotNet/Packets/MarshallObjectType.cs
@@ -1,0 +1,27 @@
+﻿namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Some of the object type values to represent the IS_CIM SelType attribute.
+    /// The remaining is found in the OCOIndex enumeration.
+    /// </summary>
+    public enum MarshallObjectType {
+        /// <summary>
+        /// InSim checkpoint.
+        /// </summary>
+        MARSH_IS_CP = 252,
+
+        /// <summary>
+        /// InSim circle.
+        /// </summary>
+        MARSH_IS_AREA = 253,
+
+        /// <summary>
+        /// Restricted area.
+        /// </summary>
+        MARSH_MARSHALL = 254,
+
+        /// <summary>
+        /// Route checker.
+        /// </summary>
+        MARSH_ROUTE = 255
+    }
+}

--- a/InSimDotNet/Packets/ModeIdentifier.cs
+++ b/InSimDotNet/Packets/ModeIdentifier.cs
@@ -1,0 +1,41 @@
+﻿namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Modes to represent the IS_CIM Mode attribute.
+    /// </summary>
+    public enum ModeIdentifier {
+        /// <summary>
+        /// Not in a special mode.
+        /// </summary>
+        CIM_NORMAL,
+
+        /// <summary>
+        /// In the options menu.
+        /// </summary>
+        CIM_OPTIONS,
+
+        /// <summary>
+        /// In the host's options menu.
+        /// </summary>
+        CIM_HOST_OPTIONS,
+
+        /// <summary>
+        /// In the garage.
+        /// </summary>
+        CIM_GARAGE,
+
+        /// <summary>
+        /// In the car selection menu.
+        /// </summary>
+        CIM_CAR_SELECT,
+
+        /// <summary>
+        /// In the track selection menu.
+        /// </summary>
+        CIM_TRACK_SELECT,
+
+        /// <summary>
+        /// In the free view mode (Shift + U).
+        /// </summary>
+        CIM_SHIFTU
+    }
+}

--- a/InSimDotNet/Packets/NormalSubMode.cs
+++ b/InSimDotNet/Packets/NormalSubMode.cs
@@ -1,0 +1,32 @@
+﻿namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Submode identifiers to represent the IS_CIM SubMode attribute when Mode
+    /// is set to CIM_NORMAL.
+    /// </summary>
+    public enum NormalSubMode {
+        /// <summary>
+        /// Not in a specific view.
+        /// </summary>
+        NRM_NORMAL,
+        
+        /// <summary>
+        /// User is viewing the car's wheel temperature (F9).
+        /// </summary>
+        NRM_WHEEL_TEMPS,
+
+        /// <summary>
+        /// User is viewing the car's wheel damage (F10).
+        /// </summary>
+        NRM_WHEEL_DAMAGE,
+
+        /// <summary>
+        /// User is viewing the setting pane for the car (F11).
+        /// </summary>
+        NRM_LIVE_SETTINGS,
+
+        /// <summary>
+        /// User is viewing the pit instructions pane (F12).
+        /// </summary>
+        NRM_PIT_INSTRUCTIONS
+    }
+}

--- a/InSimDotNet/Packets/PMOFlags.cs
+++ b/InSimDotNet/Packets/PMOFlags.cs
@@ -1,8 +1,10 @@
-﻿
+﻿using System;
+
 namespace InSimDotNet.Packets {
     /// <summary>
     /// Flags to represent the IS_AXM PMOFlags attribute.
     /// </summary>
+    [Flags]
     public enum PMOFlags {
         /// <summary>
         /// Nowt.
@@ -16,8 +18,28 @@ namespace InSimDotNet.Packets {
         PMO_FILE_END = 1,
 
         /// <summary>
-        /// InSim.txt does not include documentation for this bit.
+        /// When objects are moved or modified in the layout editor, two IS_AXM packets are
+        /// sent.  A PMO_DEL_OBJECTS followed by a PMO_ADD_OBJECTS.  In this case the flag
+        /// PMO_MOVE_MODIFY is set in the PMOFlags byte of both packets.
         /// </summary>
-        PMO_SUPPRESS_WARNINGS = 2,
+        PMO_MOVE_MODIFY = 2,
+
+        /// <summary>
+        /// If you send an IS_AXM with PMOAction of PMO_SELECTION it is possible for it to be
+        /// either a selection of real objects (as if the user selected several objects while
+        /// holding the CTRL key) or a clipboard selection (as if the user pressed CTRL+C after
+        /// selecting objects).  Clipboard is the default selection mode.  A real selection can
+        /// be set by using the PMO_SELECTION_REAL bit in the PMOFlags byte.
+        /// </summary>
+        PMO_SELECTION_REAL = 4,
+
+        /// <summary>
+        /// If you send an IS_AXM with PMOAction of PMO_ADD_OBJECTS you may wish to set the
+        /// UCID to one of the guest connections (for example if that user's action caused the
+        /// objects to be added).  In this case some validity checks are done on the guest's
+        /// computer which may report "invalid position" or "intersecting object" and delete
+        /// the objects.  This can be avoided by setting the PMO_AVOID_CHECK bit.
+        /// </summary>
+        PMO_AVOID_CHECK = 8
     }
 }

--- a/InSimDotNet/Packets/PacketType.cs
+++ b/InSimDotNet/Packets/PacketType.cs
@@ -324,6 +324,11 @@
         ISP_CSC,
 
         /// <summary>
+        /// Connection's interface mode.
+        /// </summary>
+        ISP_CIM,
+
+        /// <summary>
         /// Admin request
         /// </summary>
         IRP_ARQ = 250,

--- a/InSimDotNet/Packets/ShiftUSubMode.cs
+++ b/InSimDotNet/Packets/ShiftUSubMode.cs
@@ -1,0 +1,22 @@
+﻿namespace InSimDotNet.Packets {
+    /// <summary>
+    /// Submode identifiers to represent the IS_CIM SubMode attribute when Mode
+    /// is set to CIM_SHIFTU.
+    /// </summary>
+    public enum ShiftUSubMode {
+        /// <summary>
+        /// No buttons displayed.
+        /// </summary>
+        FVM_PLAIN,
+
+        /// <summary>
+        /// Buttons displayed (not editing)
+        /// </summary>
+        FVM_BUTTONS,
+
+        /// <summary>
+        /// Edit mode.
+        /// </summary>
+        FVM_EDIT
+    }
+}

--- a/InSimDotNet/Packets/TtcType.cs
+++ b/InSimDotNet/Packets/TtcType.cs
@@ -14,5 +14,15 @@
         /// Send IS_AXM for a layout editor selection
         /// </summary>
         TTC_SEL,
+
+        /// <summary>
+        /// Send IS_AXM every time the selection changes
+        /// </summary>
+        TTC_SEL_START,
+
+        /// <summary>
+        /// Switch off IS_AXM requested by TTC_SEL_START
+        /// </summary>
+        TTC_SET_STOP
     }
 }


### PR DESCRIPTION
Hello,
To show support for this library, I added support for the latest InSim features supported by the new version of LFS. This includes the new `IS_CIM` packet and new enum values for `IS_AXM`. I used a very similar style of code as the library and I also tested the CIM packet to make sure it worked.

The only thing I'm not sure about is how to manage the enum values of the CIM's SubMode attribute. The InSim documentation has different submode enums for different modes. I decided to make the Mode field a byte and let the user choose between the 3 different enum types in C#.

I'm available for any questions or revision in the code submitted. Thanks.
**EDIT**: If this pull request is successful, I may also add the same changes for the .NET Core version.