### PR TITLE
Fix of new ISP_MAL packet breaking behaviour

### DIFF
--- a/InSimDotNet/Packets/PacketType.cs
+++ b/InSimDotNet/Packets/PacketType.cs
@@ -299,11 +299,6 @@
         ISP_JRR,
 
         /// <summary>
-        /// get mods
-        /// </summary>
-        ISP_MAL,
-
-        /// <summary>
         /// report InSim checkpoint / InSim circle
         /// </summary>
         ISP_UCO,
@@ -332,6 +327,11 @@
         /// Connection's interface mode.
         /// </summary>
         ISP_CIM,
+
+        /// <summary>
+        /// get mods
+        /// </summary>
+        ISP_MAL,
 
         /// <summary>
         /// Admin request


### PR DESCRIPTION
Newly introduced ISP_MAL packet has been wrongly added to packet types.

It should have been added to the end of enum sequence. Instead it was placed after ISP_JRR.

Therefore all packets following after were broken.

Breaking commit: b72507b4c98beb96e58df18efe98b149ae737ef1

Affected packets:
ISP_UCO
ISP_OCO
ISP_TTC
ISP_SLC
ISP_CSC
ISP_CIM