### PR TITLE
Net6 Update to 0.6E

### DIFF
--- a/InSimDotNet/Packets/IS_AXM.cs
+++ b/InSimDotNet/Packets/IS_AXM.cs
@@ -11,6 +11,7 @@ namespace InSimDotNet.Packets {
     /// Set the ISF_AXM_EDIT flag in the IS_ISI for info about objects edited by user or InSim.
     /// </remarks>
     public class IS_AXM : IPacket, ISendable {
+        private const int MAX_AXM_OBJ = 60;
         /// <summary>
         /// Gets the size of the packet.
         /// </summary>
@@ -57,7 +58,7 @@ namespace InSimDotNet.Packets {
         public IS_AXM() {
             Size = 8;
             Type = PacketType.ISP_AXM;
-            Info = new List<ObjectInfo>(30);
+            Info = new List<ObjectInfo>(MAX_AXM_OBJ);
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace InSimDotNet.Packets {
         /// </summary>
         /// <returns>An array containing the packet data.</returns>
         public byte[] GetBuffer() {
-            if (Info.Count > 30) {
+            if (Info.Count > MAX_AXM_OBJ) {
                 throw new InvalidOperationException("IS_AXM too many objects set");
             }
 

--- a/InSimDotNet/Packets/IS_NCI.cs
+++ b/InSimDotNet/Packets/IS_NCI.cs
@@ -34,6 +34,11 @@ namespace InSimDotNet.Packets {
         public LfsLanguage Language { get; private set; }
 
         /// <summary>
+        /// Gets the license.
+        /// </summary>
+        public byte License { get; private set; }
+
+        /// <summary>
         /// Gets the LFS user ID.
         /// </summary>
         public long UserID { get; private set; }
@@ -62,7 +67,8 @@ namespace InSimDotNet.Packets {
             ReqI = reader.ReadByte();
             UCID = reader.ReadByte();
             Language = (LfsLanguage)reader.ReadByte();
-            reader.Skip(3);
+            License = reader.ReadByte();
+            reader.Skip(2);
             UserID = reader.ReadUInt32();
             IPAddress = new IPAddress(reader.ReadUInt32());
         }

--- a/InSimDotNet/Packets/IS_PLH.cs
+++ b/InSimDotNet/Packets/IS_PLH.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace InSimDotNet.Packets
+{
+    public class IS_PLH : IPacket, ISendable
+    {
+        private const int MAX_PLH_PLAYERS = 40;
+        /// <summary>
+        /// Gets the packet size.
+        /// </summary>
+        public int Size { get; private set; }
+
+        /// <summary>
+        /// Gets the packet type.
+        /// </summary>
+        public PacketType Type { get; private set; }
+
+        /// <summary>
+        /// Gets the request ID.
+        /// </summary>
+        /// <remarks>
+        /// 0 unless this is a reply to a TINY_PLH request
+        /// </remarks>
+        public byte ReqI { get; set; }
+
+        /// <summary>
+        /// Gets the number of players in this packet
+        /// </summary>
+        public byte NumP { get; set; }
+
+        /// <summary>
+        /// Gets a collection of <see cref="PlayerHCap"/> sub-packets.
+        /// </summary>
+        public IList<PlayerHCap> HCaps { get; private set; }
+
+        /// <summary>
+        /// Create a new <see cref="IS_PLH"/> object.
+        /// </summary>
+        public IS_PLH()
+        {
+            Size = 4;
+            Type = PacketType.ISP_PLH;
+            HCaps = new List<PlayerHCap>(MAX_PLH_PLAYERS);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IS_PLH"/> object.
+        /// </summary>
+        /// <param name="hcap">A collection of <see cref="PlayerHCap"/> sub-packets</param>
+        public IS_PLH(IEnumerable<PlayerHCap> hcap)
+            : this()
+        {
+            HCaps = new List<PlayerHCap>(hcap);
+            Console.WriteLine(HCaps.Count);
+            NumP = (byte)HCaps.Count;
+            Size = 4 + (NumP * 4);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IS_PLH"/> object.
+        /// </summary>
+        /// <param name="buffer">The packet data</param>
+        public IS_PLH(byte[] buffer)
+        {
+            PacketReader reader = new PacketReader(buffer);
+            Size = reader.ReadSize();
+            Type = (PacketType)reader.ReadByte();
+            ReqI = reader.ReadByte();
+            NumP = reader.ReadByte();
+            HCaps = new List<PlayerHCap>(NumP);
+
+            for (int i = 0; i < NumP; i++)
+            {
+                HCaps.Add(new PlayerHCap(reader));
+            }
+        }
+
+        /// <summary>
+        /// Gets the packet data.
+        /// </summary>
+        /// <returns>An array containing the packet data.</returns>
+        public byte[] GetBuffer()
+        {
+            if (NumP > MAX_PLH_PLAYERS)
+                throw new InvalidOperationException("IS_PLH too many player handicaps set");
+
+            Size = 4 + (HCaps.Count * 4);
+            Console.WriteLine($"Size set to {Size} with {HCaps.Count}");
+            PacketWriter writer = new PacketWriter(Size);
+            writer.WriteSize(Size);
+            writer.Write((byte)Type);
+            writer.Write(ReqI);
+            writer.Write(NumP);
+            foreach (PlayerHCap hcap in HCaps)
+            {
+                hcap.GetBuffer(writer);
+            }
+            var output = writer.GetBuffer();
+            Console.WriteLine($"Actual Size was {output.Length} and the size byte was {output[0]}");
+            return output;
+        }
+    }
+}

--- a/InSimDotNet/Packets/IS_PLH.cs
+++ b/InSimDotNet/Packets/IS_PLH.cs
@@ -52,9 +52,6 @@ namespace InSimDotNet.Packets
             : this()
         {
             HCaps = new List<PlayerHCap>(hcap);
-            Console.WriteLine(HCaps.Count);
-            NumP = (byte)HCaps.Count;
-            Size = 4 + (NumP * 4);
         }
 
         /// <summary>
@@ -86,7 +83,6 @@ namespace InSimDotNet.Packets
                 throw new InvalidOperationException("IS_PLH too many player handicaps set");
 
             Size = 4 + (HCaps.Count * 4);
-            Console.WriteLine($"Size set to {Size} with {HCaps.Count}");
             PacketWriter writer = new PacketWriter(Size);
             writer.WriteSize(Size);
             writer.Write((byte)Type);
@@ -97,7 +93,6 @@ namespace InSimDotNet.Packets
                 hcap.GetBuffer(writer);
             }
             var output = writer.GetBuffer();
-            Console.WriteLine($"Actual Size was {output.Length} and the size byte was {output[0]}");
             return output;
         }
     }

--- a/InSimDotNet/Packets/IS_PLH.cs
+++ b/InSimDotNet/Packets/IS_PLH.cs
@@ -25,9 +25,9 @@ namespace InSimDotNet.Packets
         public byte ReqI { get; set; }
 
         /// <summary>
-        /// Gets the number of players in this packet
+        /// Gets the number of players in this packet. This value is filled in automatically when sending handicaps.
         /// </summary>
-        public byte NumP { get; set; }
+        public byte NumP { get; private set; }
 
         /// <summary>
         /// Gets a collection of <see cref="PlayerHCap"/> sub-packets.
@@ -87,7 +87,7 @@ namespace InSimDotNet.Packets
             writer.WriteSize(Size);
             writer.Write((byte)Type);
             writer.Write(ReqI);
-            writer.Write(NumP);
+            writer.Write((byte)HCaps.Count);
             foreach (PlayerHCap hcap in HCaps)
             {
                 hcap.GetBuffer(writer);

--- a/InSimDotNet/Packets/LocalCarLights.cs
+++ b/InSimDotNet/Packets/LocalCarLights.cs
@@ -1,0 +1,103 @@
+﻿namespace InSimDotNet.Packets
+{
+    /// <summary>
+    /// Switches for <see cref="IS_SMALL"/> SMALL_LCL
+    /// </summary>
+    public static class LocalCarLights
+    {
+        /// <summary>
+        /// bit 0
+        /// </summary>
+        public const int LCL_SET_SIGNALS = 0x1;
+
+        /// <summary>
+        /// bit 2
+        /// </summary>
+        public const int LCL_SET_LIGHTS = 0x4;
+        
+        /// <summary>
+        /// bit 4
+        /// </summary>
+        public const int LCL_SET_FOG_REAR = 0x10;
+
+        /// <summary>
+        /// bit 5
+        /// </summary>
+        public const int LCL_SET_FOG_FRONT = 0x20;
+
+        /// <summary>
+        /// bit 6
+        /// </summary>
+        public const int LCL_SET_EXTRA = 0x40;
+
+        /// <summary>
+        /// Turn signals off
+        /// </summary>
+        public const int LCL_SIGNALS_OFF = LCL_SET_SIGNALS;
+
+        /// <summary>
+        /// Turn signal left
+        /// </summary>
+        public const int LCL_SIGNALS_LEFT = LCL_SET_SIGNALS + 0x10000;
+
+        /// <summary>
+        /// Turn signal right
+        /// </summary>
+        public const int LCL_SIGNALS_RIGHT = LCL_SET_SIGNALS + 0x20000;
+
+        /// <summary>
+        /// Turn signal hazard
+        /// </summary>
+        public const int LCL_SIGNALS_HAZARD = LCL_SET_SIGNALS + 0x30000;
+
+        /// <summary>
+        /// Turn lights off
+        /// </summary>
+        public const int LCL_LIGHTS_OFF = LCL_SET_LIGHTS;
+
+        /// <summary>
+        /// Turn side lights on
+        /// </summary>
+        public const int LCL_LIGHTS_SIDE = LCL_SET_LIGHTS + 0xA0000;
+
+        /// <summary>
+        /// Turn low lights on
+        /// </summary>
+        public const int LCL_LIGHTS_LOW = LCL_SET_LIGHTS + 0xB0000;
+
+        /// <summary>
+        /// Turn high lights on
+        /// </summary>
+        public const int LCL_LIGHTS_HIGH = LCL_SET_LIGHTS + 0xC0000;
+
+        /// <summary>
+        /// Turn rear fog lights off
+        /// </summary>
+        public const int LCL_FOG_REAR_OFF = LCL_SET_FOG_REAR;
+
+        /// <summary>
+        /// Turn rear fog lights on
+        /// </summary>
+        public const int LCL_FOG_REAR_ON = LCL_SET_FOG_REAR + 0x100000;
+
+        /// <summary>
+        /// Turn front fog lights off
+        /// </summary>
+        public const int LCL_FOG_FRONT_OFF = LCL_SET_FOG_FRONT;
+
+        /// <summary>
+        /// Turn front fog lights on
+        /// </summary>
+        public const int LCL_FOG_FRONT_ON = LCL_SET_FOG_FRONT + 0x200000;
+
+        /// <summary>
+        /// Turn extra lights off
+        /// </summary>
+        public const int LCL_EXTRA_OFF = LCL_SET_EXTRA;
+
+        /// <summary>
+        /// Turn extra lights on
+        /// </summary>
+        public const int LCL_EXTRA_ON = LCL_SET_EXTRA + 0x400000;
+    }
+}

--- a/InSimDotNet/Packets/PacketType.cs
+++ b/InSimDotNet/Packets/PacketType.cs
@@ -334,6 +334,11 @@
         ISP_MAL,
 
         /// <summary>
+        /// Player handicaps.
+        /// </summary>
+        ISP_PLH,
+
+        /// <summary>
         /// Admin request
         /// </summary>
         IRP_ARQ = 250,

--- a/InSimDotNet/Packets/PlayerHCap.cs
+++ b/InSimDotNet/Packets/PlayerHCap.cs
@@ -1,0 +1,65 @@
+﻿using System;
+
+namespace InSimDotNet.Packets
+{
+    /// <summary>
+    /// Player handicaps - there is an array of these in IS_PLH.
+    /// </summary>
+    public class PlayerHCap
+    {
+        /// <summary>
+        /// Player's unique ID
+        /// </summary>
+        public byte PLID { get; set; }
+
+        /// <summary>
+        /// Handicap flags
+        /// </summary>
+        public PlayerHCapFlag Flags { get; set; }
+
+        /// <summary>
+        /// Added mass (0kg to 200kg)
+        /// </summary>
+        public byte H_Mass { get; set; }
+
+        /// <summary>
+        /// Intake restriction (0 to  50)
+        /// </summary>
+        public byte H_TRes { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="PlayerHCap"/> object.
+        /// </summary>
+        public PlayerHCap(){}
+
+        /// <summary>
+        /// Creates a new PlayerHCap object.
+        /// </summary>
+        /// <param name="reader">A <see cref="PacketReader"/> containing packet data</param>
+        public PlayerHCap(PacketReader reader)
+        {
+            if(reader == null)
+                throw new ArgumentNullException("reader");
+
+            PLID = reader.ReadByte();
+            Flags = (PlayerHCapFlag)reader.ReadByte();
+            H_Mass = reader.ReadByte();
+            H_TRes = reader.ReadByte();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="PlayerHCap"/> object to the specified <see cref="PacketWriter"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="PacketWriter"/> to write the data to.</param>
+        public void GetBuffer(PacketWriter writer)
+        {
+            if (writer == null)
+                throw new ArgumentNullException("writer");
+
+            writer.Write(PLID);
+            writer.Write((byte)Flags);
+            writer.Write(H_Mass);
+            writer.Write(H_TRes);
+        }
+    }
+}

--- a/InSimDotNet/Packets/PlayerHCapFlag.cs
+++ b/InSimDotNet/Packets/PlayerHCapFlag.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InSimDotNet.Packets
+{
+    [Flags]
+    public enum PlayerHCapFlag
+    {
+        /// <summary>
+        /// Set mass
+        /// </summary>
+        H_Mass = 0x1,
+
+        /// <summary>
+        /// Set intake restriction
+        /// </summary>
+        H_TRes = 0x2,
+
+        /// <summary>
+        /// Add restrictions silently
+        /// </summary>
+        Silent = 0x80
+    }
+}

--- a/InSimDotNet/Packets/SmallType.cs
+++ b/InSimDotNet/Packets/SmallType.cs
@@ -51,6 +51,11 @@
         /// <summary>
         /// Set local car switches (lights, horn, siren). Use <see cref="LocalCarSwitches"/> for options.
         /// </summary>
-        SMALL_LCS = 9
+        SMALL_LCS = 9,
+
+        /// <summary>
+        /// Set local car lights. Use <see cref="LocalCarLights"/> for options."/>
+        /// </summary>
+        SMALL_LCL = 10
     }
 }


### PR DESCRIPTION
Sorry for the double PR, i found a mistake right after posting.
That bug is fixed here.

Original PR:
Added and updated the packets added or changed in the 0.7E update:
- Add SMALL_LCL
- Add IS_PLH
- Added license byte to IS_NCI
Changed the IS_AXM max objects to 60 as that's what the docs says is the maximum.