### PR TITLE
add missing ReadByte call for CarContOBJ.ZByte

### DIFF
--- a/InSimDotNet/Packets/CarContOBJ.cs
+++ b/InSimDotNet/Packets/CarContOBJ.cs
@@ -47,7 +47,7 @@ namespace InSimDotNet.Packets {
             Direction = reader.ReadByte();
             Heading = reader.ReadByte();
             Speed = reader.ReadByte();
-            reader.Skip(1);
+            Zbyte = reader.ReadByte();
             X = reader.ReadInt16();
             Y = reader.ReadInt16();
         }


### PR DESCRIPTION
This fix should be backported to other branches as well. Should I create a pull request for each one?