### PR TITLE
Add support for raw strings

### DIFF
--- a/InSimDotNet/Out/OutGaugePack.cs
+++ b/InSimDotNet/Out/OutGaugePack.cs
@@ -109,6 +109,24 @@ namespace InSimDotNet.Out {
         public int ID { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Car"/> string.
+        /// </summary>
+        public byte[] RawCar => rawCar;
+        private readonly byte[] rawCar;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Display1"/> string.
+        /// </summary>
+        public byte[] RawDisplay1 => rawDisplay1;
+        private readonly byte[] rawDisplay1;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Display2"/> string.
+        /// </summary>
+        public byte[] RawDisplay2 => rawDisplay2;
+        private readonly byte[] rawDisplay2;
+
+        /// <summary>
         /// Creates a new instance of the <see cref="OutGaugePack"/> class.
         /// </summary>
         /// <param name="buffer">A buffer contaning the packet data.</param>
@@ -119,7 +137,7 @@ namespace InSimDotNet.Out {
 
             PacketReader reader = new PacketReader(buffer);
             Time = TimeSpan.FromMilliseconds(reader.ReadUInt32());
-            Car = reader.ReadString(4);
+            Car = reader.ReadString(4, out rawCar);
             Flags = (OutGaugeFlags)reader.ReadUInt16();
             Gear = reader.ReadByte();
             PLID = reader.ReadByte();
@@ -135,8 +153,8 @@ namespace InSimDotNet.Out {
             Throttle = reader.ReadSingle();
             Brake = reader.ReadSingle();
             Clutch = reader.ReadSingle();
-            Display1 = reader.ReadString(16);
-            Display2 = reader.ReadString(16);
+            Display1 = reader.ReadString(16, out rawDisplay1);
+            Display2 = reader.ReadString(16, out rawDisplay2);
 
             // ID is optional.
             if (buffer.Length == MaxSize) {

--- a/InSimDotNet/PacketReader.cs
+++ b/InSimDotNet/PacketReader.cs
@@ -115,21 +115,20 @@ namespace InSimDotNet {
         /// <summary>
         /// Reads a LFS Car name or modded car skinID (as of 0.6W)
         /// </summary>
-        /// <param name="count">The number of bytes to read.</param>
         /// <returns>A Unicode string.</returns>
-        public string ReadCNameString(int count = 4)
-        {
+        public string ReadCNameString(out byte[] rawBytes) {
+            const int count = 4;
             position += count;
 
-            var buf = new byte[4];
-            Array.Copy(buffer, position - count, buf, 0, count);
+            rawBytes = new byte[count];
+            Buffer.BlockCopy(buffer, position - count, rawBytes, 0, count);
 
-            if (IsAlphaNumeric(buf[0]) && IsAlphaNumeric(buf[1]) && IsAlphaNumeric(buf[2]))
+            if (IsAlphaNumeric(rawBytes[0]) && IsAlphaNumeric(rawBytes[1]) && IsAlphaNumeric(rawBytes[2]))
             {
                 return LfsEncoding.Current.GetString(buffer, position - count, count);
             }
 
-            return buf[2].ToString("X2") + buf[1].ToString("X2") + buf[0].ToString("X2");
+            return rawBytes[2].ToString("X2") + rawBytes[1].ToString("X2") + rawBytes[0].ToString("X2");
 
             bool IsAlphaNumeric(byte b)
             {
@@ -141,13 +140,17 @@ namespace InSimDotNet {
         }
 
         /// <summary>
-        /// Reads a LFS encoded string from the buffer.
+        /// Reads a LFS encoded string from the buffer and
+        /// sets the rawBytes parameter to the original bytes.
         /// </summary>
         /// <param name="count">The number of bytes to read.</param>
+        /// <param name="rawBytes">Raw bytes used to create the string.</param>
         /// <returns>A Unicode string.</returns>
-        public string ReadString(int count) {
+        public string ReadString(int count, out byte[] rawBytes) {
             position += count;
-            return LfsEncoding.Current.GetString(buffer, position - count, count);
+            rawBytes = new byte[count];
+            Buffer.BlockCopy(buffer, position - count, rawBytes, 0, count);
+            return LfsEncoding.Current.GetString(rawBytes, 0, count);
         }
 
         /// <summary>

--- a/InSimDotNet/PacketWriter.cs
+++ b/InSimDotNet/PacketWriter.cs
@@ -139,13 +139,29 @@ namespace InSimDotNet {
         /// </summary>
         /// <param name="value">A Unicode string.</param>
         /// <param name="length">The maximum length of the string to write.</param>
-        public void Write(string value, int length) {
+        internal void Write(string value, int length) {
             if (value == null) {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             LfsEncoding.Current.GetBytes(value, buffer, position, length);
             position += length;
+        }
+
+        /// <summary>
+        /// If <see cref="rawValue"/> is not null, writes it to the buffer. Otherwise, writes the
+        /// specified Unicode string <see cref="value"/> to the buffer as an LFS-encoded string.
+        /// </summary>
+        /// <param name="rawValue">Raw LFS-Encoded bytes.</param>
+        /// <param name="value">A Unicode string.</param>
+        /// <param name="length">The maximum amount of bytes to write.</param>
+        public void Write(byte[] rawValue, string value, int length) {
+            if (rawValue != null)
+                Write(rawValue, length);
+            else if (value != null)
+                Write(value, length);
+            else
+                throw new ArgumentNullException($"Both {nameof(rawValue)} and {nameof(value)} was null");
         }
 
         /// <summary>

--- a/InSimDotNet/Packets/HInfo.cs
+++ b/InSimDotNet/Packets/HInfo.cs
@@ -26,6 +26,18 @@ namespace InSimDotNet.Packets {
         public byte NumConns { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="HName"/> string.
+        /// </summary>
+        public byte[] RawHName => rawHName;
+        private readonly byte[] rawHName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Track"/> string.
+        /// </summary>
+        public byte[] RawTrack => rawTrack;
+        private readonly byte[] rawTrack;
+
+        /// <summary>
         /// Creates a new <see cref="HInfo"/> sub-packet.
         /// </summary>
         /// <param name="reader">A <see cref="PacketReader"/> contaning the packet object.</param>
@@ -34,8 +46,8 @@ namespace InSimDotNet.Packets {
                 throw new ArgumentNullException("reader");
             }
 
-            HName = reader.ReadString(32);
-            Track = reader.ReadString(6);
+            HName = reader.ReadString(32, out rawHName);
+            Track = reader.ReadString(6, out rawTrack);
             Flags = (HostFlags)reader.ReadByte();
             NumConns = reader.ReadByte();
         }

--- a/InSimDotNet/Packets/IR_SEL.cs
+++ b/InSimDotNet/Packets/IR_SEL.cs
@@ -39,6 +39,24 @@ namespace InSimDotNet.Packets {
         public string Spec { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="HName"/> string.
+        /// </summary>
+        public byte[] RawHName { get => rawHName; set => rawHName = value; }
+        private byte[] rawHName;
+
+        /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Admin"/> string.
+        /// </summary>
+        public byte[] RawAdmin { get => rawAdmin; set => rawAdmin = value; }
+        private byte[] rawAdmin;
+
+        /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Spec"/> string.
+        /// </summary>
+        public byte[] RawSpec { get => rawSpec; set => rawSpec = value; }
+        private byte[] rawSpec;
+
+        /// <summary>
         /// Creates a new select host packet.
         /// </summary>
         public IR_SEL() {
@@ -59,9 +77,9 @@ namespace InSimDotNet.Packets {
             writer.Write((byte)Type);
             writer.Write((byte)ReqI);
             writer.Skip(1);
-            writer.Write(HName, 32);
-            writer.Write(Admin, 16);
-            writer.Write(Spec, 16);
+            writer.Write(rawHName, HName, 32);
+            writer.Write(rawAdmin, Admin, 16);
+            writer.Write(rawSpec, Spec, 16);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_ACR.cs
+++ b/InSimDotNet/Packets/IS_ACR.cs
@@ -45,6 +45,12 @@ namespace InSimDotNet.Packets {
         public string Text { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Text"/> string.
+        /// </summary>
+        public byte[] RawText => rawText;
+        private readonly byte[] rawText;
+
+        /// <summary>
         /// Creates a new <see cref="IS_ACR"/> object.
         /// </summary>
         public IS_ACR() {
@@ -69,7 +75,7 @@ namespace InSimDotNet.Packets {
 
             // read out variable sized packet.
             int textLength = Size - DefaultSize;
-            Text = reader.ReadString(textLength);
+            Text = reader.ReadString(textLength, out rawText);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_AXI.cs
+++ b/InSimDotNet/Packets/IS_AXI.cs
@@ -45,6 +45,12 @@ namespace InSimDotNet.Packets {
         public string LName { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="LName"/> string.
+        /// </summary>
+        public byte[] RawLName => rawLName;
+        private readonly byte[] rawLName;
+
+        /// <summary>
         /// Creates a new AutoX info packet.
         /// </summary>
         public IS_AXI() {
@@ -67,7 +73,7 @@ namespace InSimDotNet.Packets {
             AXStart = reader.ReadByte();
             NumCP = reader.ReadByte();
             NumO = reader.ReadUInt16();
-            LName = reader.ReadString(32);
+            LName = reader.ReadString(32, out rawLName);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_BTT.cs
+++ b/InSimDotNet/Packets/IS_BTT.cs
@@ -49,6 +49,12 @@ namespace InSimDotNet.Packets {
         public string Text { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Text"/> string.
+        /// </summary>
+        public byte[] RawText => rawText;
+        private readonly byte[] rawText;
+
+        /// <summary>
         /// Creates a new button type packet.
         /// </summary>
         public IS_BTT() {
@@ -72,7 +78,7 @@ namespace InSimDotNet.Packets {
             Inst = reader.ReadByte();
             TypeIn = reader.ReadByte();
             reader.Skip(1);
-            Text = reader.ReadString(96);
+            Text = reader.ReadString(96, out rawText);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_CPR.cs
+++ b/InSimDotNet/Packets/IS_CPR.cs
@@ -39,6 +39,18 @@ namespace InSimDotNet.Packets {
         public string Plate { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="PName"/> string.
+        /// </summary>
+        public byte[] RawPName => rawPName;
+        private readonly byte[] rawPName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Plate"/> string.
+        /// </summary>
+        public byte[] RawPlate => rawPlate;
+        private readonly byte[] rawPlate;
+
+        /// <summary>
         /// Creates a new connection player rename packet.
         /// </summary>
         public IS_CPR() {
@@ -59,8 +71,8 @@ namespace InSimDotNet.Packets {
             Type = (PacketType)reader.ReadByte();
             ReqI = reader.ReadByte();
             UCID = reader.ReadByte();
-            PName = reader.ReadString(24);
-            Plate = reader.ReadString(8);
+            PName = reader.ReadString(24, out rawPName);
+            Plate = reader.ReadString(8, out rawPlate);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_III.cs
+++ b/InSimDotNet/Packets/IS_III.cs
@@ -41,6 +41,12 @@ namespace InSimDotNet.Packets {
         public string Msg { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Msg"/> string.
+        /// </summary>
+        public byte[] RawMsg => rawMsg;
+        private readonly byte[] rawMsg;
+
+        /// <summary>
         /// Creates a new InSim info packet.
         /// </summary>
         public IS_III() {
@@ -66,7 +72,7 @@ namespace InSimDotNet.Packets {
 
             // read variable sized packet.
             int msgLength = Size - DefaultSize;
-            Msg = reader.ReadString(msgLength);
+            Msg = reader.ReadString(msgLength, out rawMsg);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_ISI.cs
+++ b/InSimDotNet/Packets/IS_ISI.cs
@@ -59,6 +59,18 @@ namespace InSimDotNet.Packets {
         public string IName { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Admin"/> string.
+        /// </summary>
+        public byte[] RawAdmin { get => rawAdmin; set => rawAdmin = value; }
+        private byte[] rawAdmin;
+
+        /// <summary>
+        /// Gets or sets the raw bytes of <see cref="IName"/> string.
+        /// </summary>
+        public byte[] RawIName { get => rawIName; set => rawIName = value; }
+        private byte[] rawIName;
+
+        /// <summary>
         /// Creates a new InSim initialization packet.
         /// </summary>
         public IS_ISI() {
@@ -83,8 +95,8 @@ namespace InSimDotNet.Packets {
             writer.Write(InSimVer);
             writer.Write(Prefix);
             writer.Write((ushort)Interval);
-            writer.Write(Admin, 16);
-            writer.Write(IName, 16);
+            writer.Write(rawAdmin, Admin, 16);
+            writer.Write(rawIName, IName, 16);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_ISM.cs
+++ b/InSimDotNet/Packets/IS_ISM.cs
@@ -35,6 +35,12 @@ namespace InSimDotNet.Packets {
         public string HName { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="HName"/> string.
+        /// </summary>
+        public byte[] RawHName => rawHName;
+        private readonly byte[] rawHName;
+
+        /// <summary>
         /// Creates a new InSim multiplayer packet.
         /// </summary>
         public IS_ISM() {
@@ -56,7 +62,7 @@ namespace InSimDotNet.Packets {
             reader.Skip(1);
             Host = (HostType)reader.ReadByte();
             reader.Skip(3);
-            HName = reader.ReadString(32);
+            HName = reader.ReadString(32, out rawHName);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_MSL.cs
+++ b/InSimDotNet/Packets/IS_MSL.cs
@@ -34,6 +34,12 @@ namespace InSimDotNet.Packets {
         public string Msg { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Msg"/> string.
+        /// </summary>
+        public byte[] RawMsg { get => rawMsg; set => rawMsg = value; }
+        private byte[] rawMsg;
+
+        /// <summary>
         /// Creates a new message local packet.
         /// </summary>
         public IS_MSL() {
@@ -52,7 +58,7 @@ namespace InSimDotNet.Packets {
             writer.Write((byte)Type);
             writer.Write(ReqI);
             writer.Write((byte)Sound);
-            writer.Write(Msg, 128);
+            writer.Write(rawMsg, Msg, 128);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_MST.cs
+++ b/InSimDotNet/Packets/IS_MST.cs
@@ -8,8 +8,6 @@ namespace InSimDotNet.Packets {
     /// Used to type message or command into LFS.
     /// </remarks>
     public class IS_MST : IPacket, ISendable {
-        private byte[] message;
-
         /// <summary>
         /// Gets the size of the packet.
         /// </summary>
@@ -31,6 +29,12 @@ namespace InSimDotNet.Packets {
         public string Msg { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Msg"/> string.
+        /// </summary>
+        public byte[] RawMsg { get => rawMsg; set => rawMsg = value; }
+        private byte[] rawMsg;
+
+        /// <summary>
         /// Creates a new message type packet.
         /// </summary>
         public IS_MST() {
@@ -39,8 +43,8 @@ namespace InSimDotNet.Packets {
             Msg = String.Empty;
         }
 
-        internal IS_MST(byte[] message) : this() {
-            this.message = message;
+        public IS_MST(byte[] rawMsg) : this() {
+            RawMsg = rawMsg;
         }
 
         /// <summary>
@@ -53,12 +57,7 @@ namespace InSimDotNet.Packets {
             writer.Write((byte)Type);
             writer.Write(ReqI);
             writer.Skip(1);
-            if (message == null) {
-                writer.Write(Msg, 64);
-            }
-            else {
-                writer.Write(message);
-            }
+            writer.Write(rawMsg, Msg, 64);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_MSX.cs
+++ b/InSimDotNet/Packets/IS_MSX.cs
@@ -8,8 +8,6 @@ namespace InSimDotNet.Packets {
     /// Like <see cref="IS_MST"/> but longer (cannot be used for commands).
     /// </remarks>
     public class IS_MSX : IPacket, ISendable {
-        private byte[] message;
-
         /// <summary>
         /// Gets the size of the packet.
         /// </summary>
@@ -31,6 +29,12 @@ namespace InSimDotNet.Packets {
         public string Msg { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Msg"/> string.
+        /// </summary>
+        public byte[] RawMsg { get => rawMsg; set => rawMsg = value; }
+        private byte[] rawMsg;
+
+        /// <summary>
         /// Creates a new message extended packet.
         /// </summary>
         public IS_MSX() {
@@ -39,8 +43,8 @@ namespace InSimDotNet.Packets {
             Msg = String.Empty;
         }
 
-        internal IS_MSX(byte[] message) : this() {
-            this.message = message;
+        public IS_MSX(byte[] rawMsg) : this() {
+            RawMsg = rawMsg;
         }
 
         /// <summary>
@@ -53,12 +57,7 @@ namespace InSimDotNet.Packets {
             writer.Write((byte)Type);
             writer.Write(ReqI);
             writer.Skip(1);
-            if (message == null) {
-                writer.Write(Msg, 96);
-            }
-            else {
-                writer.Write(message);
-            }
+            writer.Write(rawMsg, Msg, 96);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_NCN.cs
+++ b/InSimDotNet/Packets/IS_NCN.cs
@@ -59,6 +59,18 @@ namespace InSimDotNet.Packets {
         public bool Remote { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="UName"/> string.
+        /// </summary>
+        public byte[] RawUName => rawUName;
+        private readonly byte[] rawUName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="PName"/> string.
+        /// </summary>
+        public byte[] RawPName => rawPName;
+        private readonly byte[] rawPName;
+
+        /// <summary>
         /// Creates a new new connection packet.
         /// </summary>
         public IS_NCN() {
@@ -79,8 +91,8 @@ namespace InSimDotNet.Packets {
             Type = (PacketType)reader.ReadByte();
             ReqI = reader.ReadByte();
             UCID = reader.ReadByte();
-            UName = reader.ReadString(24);
-            PName = reader.ReadString(24);
+            UName = reader.ReadString(24, out rawUName);
+            PName = reader.ReadString(24, out rawPName);
             Admin = reader.ReadBoolean();
             Total = reader.ReadByte();
             Remote = (reader.ReadByte() & 4) > 0; // bit 2: remote

--- a/InSimDotNet/Packets/IS_NPL.cs
+++ b/InSimDotNet/Packets/IS_NPL.cs
@@ -123,6 +123,30 @@ namespace InSimDotNet.Packets {
         public byte Fuel { get; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="PName"/> string.
+        /// </summary>
+        public byte[] RawPName => rawPName;
+        private readonly byte[] rawPName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Plate"/> string.
+        /// </summary>
+        public byte[] RawPlate => rawPlate;
+        private readonly byte[] rawPlate;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="CName"/> string.
+        /// </summary>
+        public byte[] RawCName => rawCName;
+        private readonly byte[] rawCName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="SName"/> string.
+        /// </summary>
+        public byte[] RawSName => rawSName;
+        private readonly byte[] rawSName;
+
+        /// <summary>
         /// Creates a new new player packet.
         /// </summary>
         public IS_NPL() {
@@ -148,10 +172,10 @@ namespace InSimDotNet.Packets {
             UCID = reader.ReadByte();
             PType = (PlayerTypes)reader.ReadByte();
             Flags = (PlayerFlags)reader.ReadUInt16();
-            PName = reader.ReadString(24);
-            Plate = reader.ReadString(8);
-            CName = reader.ReadCNameString();
-            SName = reader.ReadString(16);
+            PName = reader.ReadString(24, out rawPName);
+            Plate = reader.ReadString(8, out rawPlate);
+            CName = reader.ReadCNameString(out rawCName);
+            SName = reader.ReadString(16, out rawSName);
             Tyres = new Tyres(
                 (TyreCompound)reader.ReadByte(),
                 (TyreCompound)reader.ReadByte(),

--- a/InSimDotNet/Packets/IS_RES.cs
+++ b/InSimDotNet/Packets/IS_RES.cs
@@ -95,6 +95,30 @@ namespace InSimDotNet.Packets {
         public TimeSpan PSeconds { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="UName"/> string.
+        /// </summary>
+        public byte[] RawUName => rawUName;
+        private readonly byte[] rawUName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="PName"/> string.
+        /// </summary>
+        public byte[] RawPName => rawPName;
+        private readonly byte[] rawPName;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Plate"/> string.
+        /// </summary>
+        public byte[] RawPlate => rawPlate;
+        private readonly byte[] rawPlate;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="CName"/> string.
+        /// </summary>
+        public byte[] RawCName => rawCName;
+        private readonly byte[] rawCName;
+
+        /// <summary>
         /// Creates a new result packet.
         /// </summary>
         public IS_RES() {
@@ -117,10 +141,10 @@ namespace InSimDotNet.Packets {
             Type = (PacketType)reader.ReadByte();
             ReqI = reader.ReadByte();
             PLID = reader.ReadByte();
-            UName = reader.ReadString(24);
-            PName = reader.ReadString(24);
-            Plate = reader.ReadString(8);
-            CName = reader.ReadCNameString();
+            UName = reader.ReadString(24, out rawUName);
+            PName = reader.ReadString(24, out rawPName);
+            Plate = reader.ReadString(8, out rawPlate);
+            CName = reader.ReadCNameString(out rawCName);
             TTime = TimeSpan.FromMilliseconds(reader.ReadUInt32());
             BTime = TimeSpan.FromMilliseconds(reader.ReadUInt32());
             reader.Skip(1);

--- a/InSimDotNet/Packets/IS_RIP.cs
+++ b/InSimDotNet/Packets/IS_RIP.cs
@@ -59,6 +59,12 @@ namespace InSimDotNet.Packets {
         public string RName { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="RName"/> string.
+        /// </summary>
+        public byte[] RawRName { get => rawRName; set => rawRName = value; }
+        private byte[] rawRName;
+
+        /// <summary>
         /// Creates a new replay information packet.
         /// </summary>
         public IS_RIP() {
@@ -87,7 +93,7 @@ namespace InSimDotNet.Packets {
             CTime = TimeSpan.FromMilliseconds(reader.ReadUInt32());
             TTime = TimeSpan.FromMilliseconds(reader.ReadUInt32());
 
-            RName = reader.ReadString(64);
+            RName = reader.ReadString(64, out rawRName);
         }
 
         /// <summary>
@@ -109,7 +115,8 @@ namespace InSimDotNet.Packets {
             writer.Write((uint)CTime.TotalMilliseconds / 10);
             writer.Write((uint)TTime.TotalMilliseconds / 10);
 
-            writer.Write(RName, 64);
+            writer.Write(rawRName, RName, 64);
+
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_RST.cs
+++ b/InSimDotNet/Packets/IS_RST.cs
@@ -90,6 +90,12 @@ namespace InSimDotNet.Packets {
         public int Split3 { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Track"/> string.
+        /// </summary>
+        public byte[] RawTrack => rawTrack;
+        private readonly byte[] rawTrack;
+
+        /// <summary>
         /// Creates a new race start packet.
         /// </summary>
         public IS_RST() {
@@ -113,7 +119,7 @@ namespace InSimDotNet.Packets {
             QualMins = reader.ReadByte();
             NumP = reader.ReadByte();
             Timing = reader.ReadByte();
-            Track = reader.ReadString(6);
+            Track = reader.ReadString(6, out rawTrack);
             Weather = reader.ReadByte();
             Wind = reader.ReadByte();
             Flags = (RaceFlags)reader.ReadUInt16();

--- a/InSimDotNet/Packets/IS_SLC.cs
+++ b/InSimDotNet/Packets/IS_SLC.cs
@@ -29,6 +29,12 @@
         public string CName { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="CName"/> string.
+        /// </summary>
+        public byte[] RawCName => rawCName;
+        private readonly byte[] rawCName;
+
+        /// <summary>
         /// Creates a new IS_SLC packet.
         /// </summary>
         /// <param name="buffer">A buffer containing the packet byte data.</param>
@@ -38,7 +44,7 @@
             Type = (PacketType)reader.ReadByte();
             ReqI = reader.ReadByte();
             UCID = reader.ReadByte();
-            CName = reader.ReadCNameString();
+            CName = reader.ReadCNameString(out rawCName);
         }
     }
 }

--- a/InSimDotNet/Packets/IS_SSH.cs
+++ b/InSimDotNet/Packets/IS_SSH.cs
@@ -35,6 +35,12 @@ namespace InSimDotNet.Packets {
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the raw bytes of <see cref="Name"/> string.
+        /// </summary>
+        public byte[] RawName { get => rawName; set => rawName = value; }
+        private byte[] rawName;
+
+        /// <summary>
         /// Creates a new screenshot packet.
         /// </summary>
         public IS_SSH() {
@@ -55,7 +61,7 @@ namespace InSimDotNet.Packets {
             ReqI = reader.ReadByte();
             Error = (ScreenshotError)reader.ReadByte();
             reader.Skip(4);
-            Name = reader.ReadString(32);
+            Name = reader.ReadString(32, out rawName);
         }
 
         /// <summary>
@@ -69,7 +75,7 @@ namespace InSimDotNet.Packets {
             writer.Write(ReqI);
             writer.Write((byte)Error);
             writer.Skip(4);
-            writer.Write(Name, 32);
+            writer.Write(rawName, Name, 32);
             return writer.GetBuffer();
         }
     }

--- a/InSimDotNet/Packets/IS_STA.cs
+++ b/InSimDotNet/Packets/IS_STA.cs
@@ -90,6 +90,12 @@ namespace InSimDotNet.Packets {
         public byte Wind { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Track"/> string.
+        /// </summary>
+        public byte[] RawTrack => rawTrack;
+        private readonly byte[] rawTrack;
+
+        /// <summary>
         /// Creates a new state packet.
         /// </summary>
         public IS_STA() {
@@ -120,7 +126,7 @@ namespace InSimDotNet.Packets {
             QualMins = reader.ReadByte();
             RaceLaps = reader.ReadByte();
             reader.Skip(2);
-            Track = reader.ReadString(6);
+            Track = reader.ReadString(6, out rawTrack);
             Weather = reader.ReadByte();
             Wind = reader.ReadByte();
         }

--- a/InSimDotNet/Packets/IS_VER.cs
+++ b/InSimDotNet/Packets/IS_VER.cs
@@ -39,6 +39,18 @@ namespace InSimDotNet.Packets {
         public int InSimVer { get; private set; }
 
         /// <summary>
+        /// Gets the raw bytes of <see cref="Version"/> string.
+        /// </summary>
+        public byte[] RawVersion => rawVersion;
+        private readonly byte[] rawVersion;
+
+        /// <summary>
+        /// Gets the raw bytes of <see cref="Product"/> string.
+        /// </summary>
+        public byte[] RawProduct => rawProduct;
+        private readonly byte[] rawProduct;
+
+        /// <summary>
         /// Creates a new version packet.
         /// </summary>
         public IS_VER() {
@@ -59,8 +71,8 @@ namespace InSimDotNet.Packets {
             Type = (PacketType)reader.ReadByte();
             ReqI = reader.ReadByte();
             reader.Skip(1);
-            Version = reader.ReadString(8);
-            Product = reader.ReadString(6);
+            Version = reader.ReadString(8, out rawVersion);
+            Product = reader.ReadString(6, out rawProduct);
             InSimVer = reader.ReadByte();
             reader.Skip(1);
         }


### PR DESCRIPTION
> Adds raw string alternatives to auto converted unicode strings
> Helps avoid data loss while converting LFS-encoded strings

Why did I add such feature?
It gives us more precision and control over the bytes that we receive from and send to InSim. More specifically: to avoid data-losses caused by unicode conversion.

I was using LfsUnicodeEncoding2 with an LfsEncodingChecker class that would do a round-trip to check if there is a data loss while using GetString and GetBytes. It worked totally fine as long as the bytes that I received were valid LFS-encoded strings. Someone had manually saved their cfg.txt and it converted some of the Japanese characters in their nickname (`Ply Name` in cfg.txt) into UTF-8 replacement characters `�`, which got encoded as `EFBFBD`, which isn't a valid sequence in LFS-encoded strings. LfsUnicodeEncoding2 would fall back to `?` for `EFBF`, then round-trip would make it `3F` (ASCII question mark), which would make my checker warn about the data-loss.

Related forum [thread](https://www.lfs.net/forum/thread/112711):
> In Japanese code page, LFS displays EFBF sequence as a square (no match) and BD as ｽ.
<img width="936" height="140" alt="image" src="https://github.com/user-attachments/assets/dca7f460-7b0c-4a78-9612-366002c63412" />

I didn't test all the changes but these packets seem to work fine: `IS_NCN`, `IS_NPL`, `IS_CPR`, `IS_TOC`, `IS_BTN`. I used both unicode strings and raw bytes in my code; they worked fine together.